### PR TITLE
fix: ajusta padding da seção de equipe

### DIFF
--- a/src/styles/Team.css
+++ b/src/styles/Team.css
@@ -1,6 +1,6 @@
 .team {
   text-align: center;
-  padding: 60px 20px;
+  padding: 60px 0;
 }
 
 .team h1 {


### PR DESCRIPTION
Faz uma pequena atualização na classe `.team` no arquivo `src/styles/Team.css`. 
O preenchimento horizontal foi alterado de `20px` para `0`, o que aumentará o espaço horizontal utilizável para o conteúdo.

Removendo o espaço em branco que possui anteriormente 

<img width="1919" height="592" alt="{EA602277-062D-494F-9453-69D9AAE5A9A2}" src="https://github.com/user-attachments/assets/183f8981-5028-4366-8538-1d98e1530c3d" />
