### PR TITLE
fix: corrige overflow da seção de equipe e ajusta largura do carrossel

### DIFF
--- a/src/styles/Team.css
+++ b/src/styles/Team.css
@@ -1,6 +1,7 @@
 .team {
   text-align: center;
   padding: 60px 0;
+  overflow-x: hidden;
 }
 
 .team h2 {
@@ -16,7 +17,8 @@
 /* CARROSSEL */
 .carousel {
   overflow: hidden;
-  width: 95%;
+  width: 100%;
+  margin: 0 auto;
 }
 
 .carousel-track {


### PR DESCRIPTION
This pull request makes minor styling adjustments to the team section carousel, primarily to improve layout and visual consistency.

- Carousel layout improvements:
  * Set the `.carousel` width to 100% and centered it with `margin: 0 auto;` for better alignment.

- Overflow handling:
  * Added `overflow-x: hidden;` to the `.team` class to prevent horizontal scroll issues.